### PR TITLE
Added multiple trigger words

### DIFF
--- a/.guysrc.json
+++ b/.guysrc.json
@@ -1,0 +1,7 @@
+{
+  "keywords": [
+    "guys",
+    "blokes",
+    "buggers"
+  ]
+}

--- a/index.js
+++ b/index.js
@@ -2,21 +2,29 @@ require('dotenv').config()
 
 const { createEventAdapter } = require('@slack/events-api')
 const { WebClient } = require('@slack/web-api')
+const { keywords } = require('./.guysrc.json')
 const web = new WebClient(process.env.SLACK_TOKEN)
 const slackEvents = createEventAdapter(process.env.SLACK_SIGNING_SECRET)
 const port = process.env.PORT || 3000
 
+let word = ''
+const checker = (value) => keywords.some((e) => value.includes(e))
+
 slackEvents.on('message', (event) => {
   if (
     Object.prototype.hasOwnProperty.call(event, 'text') &&
-    event.text.toLowerCase().includes('guys')
+    event.text.toLowerCase().split(' ').filter(checker)
   ) {
     (async () => {
+      word = event.text.toLowerCase()
+        .split(' ').filter(checker)[0]
+        .replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, '')
+        .replace(/\s{2,}/g, '')
       const messageBody =
         process.env.GUYS_MESSAGE ||
         'Please bear in mind that the makeup of this Slack is ' +
         'very diverse, and some people feel excluded by the ' +
-        'use of the term “guys”. Maybe you could try using ' +
+        'use of the term “' + word + '”. Maybe you could try using ' +
         '_people_, _team_, _all_, _folks_, _everyone_, or _y\'all_?'
       const infoLink =
         process.env.GUYS_INFO_LINK ||


### PR DESCRIPTION
Added `.guysrc.json` which shall act as a dictionary of potentially exclusive or condescending words. The bot shall reply with the first word that it finds stripped of any whitespaces and punctuation.

### Proof of Concept

```js
const keywords = [
    "guys",
    "blokes",
    "buggers"
]

const text = 'hey buggers, nice to see yall'
const checker = (value) => keywords.some((e) => value.includes(e))

let word = text.toLowerCase()
        .split(' ').filter(checker)[0]
        .replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, '')
        .replace(/\s{2,}/g, '')

const messageBody =
  'Please bear in mind that the makeup of this Slack is ' +
  'very diverse, and some people feel excluded by the ' +
  'use of the term “' + word + '”. Maybe you could try using ' +
  '_people_, _team_, _all_, _folks_, _everyone_, or _y\'all_?'

console.log(messageBody)
```

```
Please bear in mind that the makeup of this Slack is very diverse, 
and some people feel excluded by the use of the term “buggers”.
Maybe you could try using _people_, _team_, _all_, _folks_, _everyone_,
or _y'all_?
```